### PR TITLE
Replace directory separator from '\' to platform specific char.

### DIFF
--- a/VSFile/VisualStudioFile.cs
+++ b/VSFile/VisualStudioFile.cs
@@ -74,6 +74,9 @@ namespace VSFile
 			if (string.IsNullOrEmpty(fileExtension) || string.IsNullOrEmpty(filePath))
 				throw new ArgumentException();
 
+			// For unix.
+			filePath = filePath.Replace('\\', Path.DirectorySeparatorChar);
+
 			m_directoryPath = Path.GetDirectoryName(filePath);
 
 			// Use current directory if no directory information in file path.


### PR DESCRIPTION
I was using the stylecopcli on Mac and found some problems.
So I fixed it and worked well.

As .csproj file contains windows style directory separator '\',
source files path can not be recognized on unix-like os.
('/' is unix-like os directory separator)
